### PR TITLE
Fix: style objects always being set on update

### DIFF
--- a/packages/lib/src/dom.ts
+++ b/packages/lib/src/dom.ts
@@ -168,7 +168,10 @@ function setStyleProp(dom: SomeElement, value: unknown, prev: unknown) {
       const newStyleString = styleObjectToCss(
         value as Partial<CSSStyleDeclaration>
       )
-      if (newStyleString !== prev) {
+			const prevStyleString = prev == null ? null : styleObjectToCss(
+        prev as Partial<CSSStyleDeclaration>
+      )
+      if (newStyleString !== prevStyleString) {
         dom.setAttribute("style", newStyleString)
       }
       break


### PR DESCRIPTION
# TLDR
if you pass a object into a `style` attribute it would compare the new string version to the previous object, always resulting in it being set on every update.

# Additional info
none.