### PR TITLE
fix:  detects which packageManager is installed

### DIFF
--- a/packages/create-kaioken/index.js
+++ b/packages/create-kaioken/index.js
@@ -14,6 +14,9 @@ const detectPackageManager = () => {
   if(execPath.includes('yarn')) {
     return 'yarn';
   }
+  if(execPath.includes('bun')) {
+    return 'bun';
+  }
   return 'npm';
 }
 
@@ -148,6 +151,9 @@ program
     } else if(packageManager === 'yarn') {
       installCwd = dest;
       devCmd = 'yarn dev';
+    } else if(packageManager === 'bun') {
+      installCwd = dest;
+      devCmd = 'bun dev';
     } else {
       installCwd = dest;
       devCmd = 'npm run dev';

--- a/packages/create-kaioken/index.js
+++ b/packages/create-kaioken/index.js
@@ -6,6 +6,16 @@ import { program } from "commander"
 import inquirer from "inquirer"
 import { execa } from "execa"
 
+const executingPackageManager = process.argv[1]
+  .split("/")
+  .find(
+    (x) =>
+      x.includes("pnpm") ||
+      x.includes("yarn") ||
+      x.includes("bun") ||
+      x.includes("npx")
+  ) || "npx"
+
 const templates = [
   {
     name: "CSR (Client-side rendering)",
@@ -136,7 +146,7 @@ program
         name: "packageManager",
         message: "Which package manager do you want to use?",
         choices: availablePackageManagers,
-        default: 'npm'
+        default: executingPackageManager === "npx" ? "npm" : executingPackageManager,
       },
     ])
 
@@ -190,13 +200,3 @@ function hasGlobalInstallation(pm) {
     })
     .catch(() => false)
 }
-
-const executingPackageManager = process.argv[1]
-  .split("/")
-  .find(
-    (x) =>
-      x.includes("pnpm") ||
-      x.includes("yarn") ||
-      x.includes("bun") ||
-      x.includes("npx")
-  )

--- a/packages/create-kaioken/index.js
+++ b/packages/create-kaioken/index.js
@@ -129,18 +129,6 @@ program
       fs.rmSync(gitFolder, { recursive: true, force: true })
     }
 
-    const { pnpm, yarn, bun } = await detectPackageManager()
-    let devCmd;
-    if (pnpm) {
-      devCmd = "pnpm dev"
-    } else if (yarn) {
-      devCmd = "yarn dev"
-    } else if (bun) {
-      devCmd = "bun dev"
-    } else {
-      devCmd = "npm run dev"
-    }
-
     const availablePackageManagers = await detectPackageManager();
     const { packageManager } = await inquirer.prompt([
       {
@@ -152,6 +140,16 @@ program
       },
     ])
 
+    let devCmd;
+    if (packageManager === "pnpm") {
+      devCmd = "pnpm dev"
+    } else if (packageManager === "yarn") {
+      devCmd = "yarn dev"
+    } else if (packageManager === "bun") {
+      devCmd = "bun dev"
+    } else {
+      devCmd = "npm run dev"
+    }
     console.log(`Project template downloaded. Get started by running the following:
     
     

--- a/packages/create-kaioken/index.js
+++ b/packages/create-kaioken/index.js
@@ -4,22 +4,21 @@ import path from "node:path"
 import { simpleGit } from "simple-git"
 import { program } from "commander"
 import inquirer from "inquirer"
-import { execa }  from "execa"
-
+import { execa } from "execa"
 
 // detect the package manager used by the user
 const detectPackageManager = () => {
-  const execPath = process.env.npm_execpath || '';
-  if(execPath.includes('pnpm')) {
-    return 'pnpm';
+  const execPath = process.env.npm_execpath || ""
+  if (execPath.includes("pnpm")) {
+    return "pnpm"
   }
-  if(execPath.includes('yarn')) {
-    return 'yarn';
+  if (execPath.includes("yarn")) {
+    return "yarn"
   }
-  if(execPath.includes('bun')) {
-    return 'bun';
+  if (execPath.includes("bun")) {
+    return "bun"
   }
-  return 'npm';
+  return "npm"
 }
 
 const templates = [
@@ -145,25 +144,36 @@ program
       fs.rmSync(gitFolder, { recursive: true, force: true })
     }
 
-    const packageManager = await detect();
-    console.log('detected',  packageManager.yarn, packageManager.pnpm, packageManager.bun);
-    let installCwd, devCmd;
-    if(packageManager.pnpm === 'pnpm') {
-      installCwd = dest;
-      devCmd = 'pnpm dev';
-    } else if(packageManager.yarn === 'yarn') {
-      installCwd = dest;
-      devCmd = 'yarn dev';
-    } else if(packageManager.bun === 'bun') {
-      installCwd = dest;
-      devCmd = 'bun dev';
+    const { pnpm, yarn, bun } = await detect()
+    console.log("detected", pnpm, yarn, bun)
+    let installCwd, devCmd
+    if (pnpm) {
+      devCmd = "pnpm dev"
+    } else if (yarn) {
+      devCmd = "yarn dev"
+    } else if (bun) {
+      devCmd = "bun dev"
     } else {
-      installCwd = dest;
-      devCmd = 'npm run dev';
+      devCmd = "npm run dev"
     }
 
+    const { packageManager } = await inquirer.prompt([
+      {
+        type: "list",
+        name: "packageManager",
+        message: "Which package manager do you want to use?",
+        choices: [
+          { name: "npm", value: "npm" },
+          { name: "pnpm", value: "pnpm" },
+          { name: "yarn", value: "yarn" },
+        ],
+        default: detectedPackageManager,
+      },
+    ])
 
     console.log(`Project template downloaded. Get started by running the following:
+    
+    
 
   cd ${dest}
   ${packageManager} install
@@ -186,7 +196,7 @@ const detect = async () => {
   return {
     yarn: hasYarn,
     pnpm: hasPnpm,
-    bun: hasBun
+    bun: hasBun,
   }
 }
 
@@ -198,7 +208,7 @@ export { detect }
 function hasGlobalInstallation(pm) {
   return execa(pm, ["--version"])
     .then((res) => {
-      return /^\d+.\d+.\d+$/.test(res.stdout);
+      return /^\d+.\d+.\d+$/.test(res.stdout)
     })
-    .catch(() => false);
+    .catch(() => false)
 }

--- a/packages/create-kaioken/index.js
+++ b/packages/create-kaioken/index.js
@@ -5,6 +5,18 @@ import { simpleGit } from "simple-git"
 import { program } from "commander"
 import inquirer from "inquirer"
 
+// detect the package manager used by the user
+const detectPackageManager = () => {
+  const execPath = process.env.npm_execpath || '';
+  if(execPath.includes('pnpm')) {
+    return 'pnpm';
+  }
+  if(execPath.includes('yarn')) {
+    return 'yarn';
+  }
+  return 'npm';
+}
+
 const templates = [
   {
     name: "CSR (Client-side rendering)",
@@ -127,11 +139,26 @@ program
     if (fs.existsSync(gitFolder)) {
       fs.rmSync(gitFolder, { recursive: true, force: true })
     }
+
+    const packageManager = detectPackageManager();
+    let installCwd, devCmd;
+    if(packageManager === 'pnpm') {
+      installCwd = dest;
+      devCmd = 'pnpm dev';
+    } else if(packageManager === 'yarn') {
+      installCwd = dest;
+      devCmd = 'yarn dev';
+    } else {
+      installCwd = dest;
+      devCmd = 'npm run dev';
+    }
+
+
     console.log(`Project template downloaded. Get started by running the following:
 
   cd ${dest}
-  pnpm install
-  pnpm dev
+  ${packageManager} install
+  ${devCmd}
 `)
   })
 

--- a/packages/create-kaioken/index.js
+++ b/packages/create-kaioken/index.js
@@ -162,9 +162,7 @@ program
 
 program.parse(process.argv)
 
-/**
- * @returns an object of booleans indicating which package managers are available
- */
+
 const detectPackageManager = async () => {
   const [hasYarn, hasPnpm, hasBun] = await Promise.all([
     hasGlobalInstallation("yarn"),
@@ -179,11 +177,6 @@ const detectPackageManager = async () => {
   packageManagers.push({ name: "npm", value: "npm" }); // npm as fallback
 
   return packageManagers;
-  // return {
-  //   yarn: hasYarn,
-  //   pnpm: hasPnpm,
-  //   bun: hasBun,
-  // }
 }
 
 

--- a/packages/create-kaioken/package.json
+++ b/packages/create-kaioken/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "commander": "^12.1.0",
+    "execa": "^9.3.1",
     "inquirer": "^10.0.4",
     "simple-git": "^3.25.0"
   },


### PR DESCRIPTION
This detects which packageManager is installed by using process.env.npm_execpath 
If it's not set to pnpm, yarn, or bun. The default becomes npm for the install instructions.