### PR TITLE
Feat/hook hmr invalidation rework

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaioken",
-  "version": "0.35.10",
+  "version": "0.36.0-0",
   "description": "A powerful, easy-to-use rendering library with a tiny footprint",
   "main": "index.js",
   "type": "module",

--- a/packages/lib/src/appContext.ts
+++ b/packages/lib/src/appContext.ts
@@ -16,6 +16,11 @@ export interface AppContextOptions {
    * @default 50
    */
   maxFrameMs?: number
+  /**
+   * Enables runtime hook invalidation
+   * @default false
+   */
+  useRuntimeHookInvalidation?: boolean
   name?: string
 }
 
@@ -32,7 +37,7 @@ export class AppContext<T extends Record<string, unknown> = {}> {
   constructor(
     private appFunc: (props: T) => JSX.Element,
     private appProps = {},
-    private options?: AppContextOptions
+    public options?: AppContextOptions
   ) {
     this.id = appCounter++
     this.name = options?.name ?? "App-" + this.id

--- a/packages/lib/src/hmr.ts
+++ b/packages/lib/src/hmr.ts
@@ -133,10 +133,13 @@ export function createHMRContext() {
               if (!ctx.options?.useRuntimeHookInvalidation) {
                 if (!vNode.hooks) return
                 for (let i = 0; i < hooksToReset.length; i++) {
-                  const hookIndex = hooksToReset[i]
-                  cleanupHook(vNode.hooks[hookIndex])
-                  // @ts-ignore
-                  vNode.hooks[hookIndex] = undefined
+                  const hook = vNode.hooks[hooksToReset[i]]
+                  if (!hook.debug?.handleRawArgsChanged) {
+                    console.log("yeeting hook", hook)
+                    cleanupHook(hook)
+                    // @ts-ignore this is fine and will cause the hook to be recreated
+                    vNode.hooks[hooksToReset[i]] = undefined
+                  }
                 }
               }
             }

--- a/packages/lib/src/hmr.ts
+++ b/packages/lib/src/hmr.ts
@@ -4,6 +4,7 @@ import { __DEV__ } from "./env.js"
 import { Signal } from "./signals/base.js"
 import { traverseApply } from "./utils.js"
 import type { WatchEffect } from "./signals/watch"
+import { cleanupHook } from "./hooks"
 
 export type HMRAccept<T = {}> = {
   provide: () => T
@@ -133,6 +134,7 @@ export function createHMRContext() {
                 if (!vNode.hooks) return
                 for (let i = 0; i < hooksToReset.length; i++) {
                   const hookIndex = hooksToReset[i]
+                  cleanupHook(vNode.hooks[hookIndex])
                   // @ts-ignore
                   vNode.hooks[hookIndex] = undefined
                 }

--- a/packages/lib/src/hmr.ts
+++ b/packages/lib/src/hmr.ts
@@ -15,7 +15,16 @@ export type GenericHMRAcceptor<T = {}> = {
   [$HMR_ACCEPT]: HMRAccept<T>
 }
 
-type HotVar = Kaioken.FC | Store<any, any> | Signal<any> | Kaioken.Context<any>
+type HotVarDesc =
+  | {
+      type: "component"
+      value: Kaioken.FC
+      hooks: Array<{ name: string; args: string }>
+    }
+  | {
+      type: string
+      value: Store<any, any> | Signal<any> | Kaioken.Context<any>
+    }
 
 export function isGenericHmrAcceptor(
   thing: unknown
@@ -30,9 +39,15 @@ export function isGenericHmrAcceptor(
 }
 
 type ModuleMemory = {
-  hotVars: Map<string, HotVar>
+  hotVars: Map<string, HotVarDesc>
   unnamedWatchers: Array<WatchEffect>
   fileLink: string
+}
+
+type HotVarRegistrationEntry = {
+  type: string
+  value: HotVarDesc
+  hooks?: Array<{ name: string; args: string }>
 }
 
 export function createHMRContext() {
@@ -58,42 +73,70 @@ export function createHMRContext() {
     currentModuleMemory = mod!
   }
 
-  const register = (hotVars: Record<string, HotVar>) => {
+  const register = (
+    hotVarRegistrationEntries: Record<string, HotVarRegistrationEntry>
+  ) => {
     if (currentModuleMemory === null)
       throw new Error("[kaioken]: HMR could not register: No active module")
 
-    for (const [name, newVar] of Object.entries(hotVars)) {
-      const oldVar = currentModuleMemory.hotVars.get(name)
-      if (typeof newVar === "function") {
+    for (const [name, newEntry] of Object.entries(hotVarRegistrationEntries)) {
+      const oldEntry = currentModuleMemory.hotVars.get(name)
+      if (typeof newEntry.value === "function") {
         // @ts-ignore - this is how we tell devtools what file the component is from
-        newVar.__devtoolsFileLink = currentModuleMemory.fileLink + ":0"
-        if (oldVar) {
+        newEntry.value.__devtoolsFileLink = currentModuleMemory.fileLink + ":0"
+        if (oldEntry?.value) {
           /**
            * this is how, when the previous function has been stored somewhere else (eg. by Vike),
            * we can trace it to its latest version
            */
           // @ts-ignore
-          oldVar.__next = newVar
+          oldEntry.value.__next = newEntry.value
         }
       }
-      currentModuleMemory.hotVars.set(name, newVar)
-      if (!oldVar) continue
-      if (isGenericHmrAcceptor(oldVar) && isGenericHmrAcceptor(newVar)) {
-        newVar[$HMR_ACCEPT].inject(oldVar[$HMR_ACCEPT].provide())
-        oldVar[$HMR_ACCEPT].destroy()
+      currentModuleMemory.hotVars.set(name, newEntry as any)
+      if (!oldEntry) continue
+      if (
+        isGenericHmrAcceptor(oldEntry.value) &&
+        isGenericHmrAcceptor(newEntry.value)
+      ) {
+        newEntry.value[$HMR_ACCEPT].inject(
+          oldEntry.value[$HMR_ACCEPT].provide()
+        )
+        oldEntry.value[$HMR_ACCEPT].destroy()
         continue
       }
-      if (typeof oldVar === "function" && typeof newVar === "function") {
+      if (oldEntry.type === "component" && newEntry.type === "component") {
+        const hooksToReset: number[] = []
+        if ("hooks" in oldEntry && "hooks" in newEntry) {
+          const hooks = newEntry.hooks!
+          for (let i = 0; i < hooks.length; i++) {
+            const hook = hooks[i]
+            const oldHook = oldEntry.hooks[i]
+            if (oldHook && hook.args === oldHook.args) {
+              continue
+            }
+            hooksToReset.push(i)
+          }
+        }
+
         window.__kaioken!.apps.forEach((ctx) => {
           if (!ctx.mounted || !ctx.rootNode) return
           traverseApply(ctx.rootNode, (vNode) => {
-            if (vNode.type === oldVar) {
-              vNode.type = newVar
+            if (vNode.type === oldEntry.value) {
+              vNode.type = newEntry.value as any
               vNode.hmrUpdated = true
               if (vNode.prev) {
-                vNode.prev.type = newVar
+                vNode.prev.type = newEntry.value as any
               }
               ctx.requestUpdate(vNode)
+              if (!ctx.options?.useRuntimeHookInvalidation) {
+                if (!vNode.hooks) return
+                for (let i = 0; i < hooksToReset.length; i++) {
+                  const hookIndex = hooksToReset[i]
+                  // @ts-ignore
+                  vNode.hooks[hookIndex] = undefined
+                }
+              }
             }
           })
         })

--- a/packages/lib/src/hooks/utils.ts
+++ b/packages/lib/src/hooks/utils.ts
@@ -32,7 +32,10 @@ let nextHookDevInvalidationValue: string | undefined
  */
 const useHookHMRInvalidation = (...values: unknown[]) => {
   if (__DEV__) {
-    nextHookDevInvalidationValue = safeStringify(values)
+    const ctx = getVNodeAppContext(node.current!)
+    if (ctx.options?.useRuntimeHookInvalidation) {
+      nextHookDevInvalidationValue = safeStringify(values)
+    }
   }
 }
 
@@ -174,7 +177,10 @@ function useHook<
     const oldAsDevHook = oldHook as DevHook<T> | undefined
     const asDevHook = hook as DevHook<T>
     let hmrInvalid = false
-    if (nextHookDevInvalidationValue !== undefined) {
+    if (
+      ctx.options?.useRuntimeHookInvalidation &&
+      nextHookDevInvalidationValue !== undefined
+    ) {
       if (!oldAsDevHook) {
         asDevHook.devInvalidationValue = nextHookDevInvalidationValue // store our initial 'devInvalidationValue'
       } else if (

--- a/packages/lib/src/signals/base.ts
+++ b/packages/lib/src/signals/base.ts
@@ -172,8 +172,10 @@ export const useSignal = <T>(initial: T, displayName?: string) => {
   return useHook(
     "useSignal",
     { signal: undefined as any as Signal<T> },
-    ({ hook, isInit, vNode }) => {
+    ({ hook, isInit }) => {
       if (isInit) {
+        hook.signal = new Signal(initial, displayName)
+        hook.cleanup = () => Signal.dispose(hook.signal)
         if (__DEV__) {
           hook.debug = {
             get: () => ({
@@ -183,13 +185,11 @@ export const useSignal = <T>(initial: T, displayName?: string) => {
             set: ({ value }) => {
               hook.signal.sneak(value)
             },
-          }
-          if (hook.signal && vNode.hmrUpdated) {
-            hook.signal.value = initial
+            handleRawArgsChanged: () => {
+              hook.signal.value = initial
+            },
           }
         }
-        hook.signal ??= new Signal(initial, displayName)
-        hook.cleanup = () => Signal.dispose(hook.signal)
       }
       return hook.signal
     }

--- a/packages/lib/src/signals/watch.ts
+++ b/packages/lib/src/signals/watch.ts
@@ -97,12 +97,15 @@ export const useWatch = (getter: () => (() => void) | void) => {
   }
   return useHook(
     "useWatch",
-    {
-      watcher: null as any as WatchEffect,
-    },
-    ({ hook, isInit }) => {
+    { watcher: null as any as WatchEffect },
+    ({ hook, isInit, vNode }) => {
+      if (__DEV__) {
+        if (vNode.hmrUpdated) {
+          hook.cleanup?.()
+          isInit = true
+        }
+      }
       if (isInit) {
-        hook.cleanup?.()
         hook.watcher = new WatchEffect(getter)
         hook.watcher.start()
         hook.cleanup = () => hook.watcher?.stop()

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -149,6 +149,12 @@ declare global {
     interface HookDebug<T extends Record<string, any>> {
       get: () => T
       set?: (value: ReturnType<this["get"]>) => void
+      /**
+       * If provided, during development, when the raw arguments of the hook change,
+       * the hook will persist instead of being recreated. This function will be called
+       * during the next render, before the hook is called.
+       */
+      handleRawArgsChanged?: () => void
     }
     type Hook<T> = T & {
       cleanup?: () => void

--- a/packages/vite-plugin-kaioken/package.json
+++ b/packages/vite-plugin-kaioken/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-kaioken",
-  "version": "0.15.0",
+  "version": "0.16.0-0",
   "description": "",
   "main": "dist/index.js",
   "type": "module",
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "kaioken": ">=0.35.0"
+    "kaioken": ">=0.36.0-0"
   },
   "devDependencies": {
     "@types/node": "^22.7.4",

--- a/packages/vite-plugin-kaioken/src/codegen.ts
+++ b/packages/vite-plugin-kaioken/src/codegen.ts
@@ -194,8 +194,8 @@ function findNodeName(node: AstNode): string | void {
 function addHotVarDesc(node: AstNode, names: Set<HotVarDesc>, type: string) {
   const name = findNodeName(node)
   if (!name && type === "component") {
-    console.error("VPK: failed to find component name", node)
-    throw new Error("Component name not found")
+    console.error("[vite-plugin-kaioken]: failed to find component name", node)
+    throw new Error("[vite-plugin-kaioken]: Component name not found")
   }
   if (name) {
     names.add({ type, name })
@@ -231,7 +231,10 @@ function getComponentHookArgs(
     if (findNode(node, isNodeCreateElementExpression)) {
       const name = findNodeName(node)
       if (!name) {
-        console.error("VPK: failed to find component name", node)
+        console.error(
+          "[vite-plugin-kaioken]: failed to find component name",
+          node
+        )
         continue
       }
 
@@ -260,7 +263,7 @@ function getComponentHookArgs(
                     }
                   } catch (error) {
                     console.error(
-                      "err thrown when getting hook args (VariableDeclaration)",
+                      "[vite-plugin-kaioken]: err thrown when getting hook args (VariableDeclaration)",
                       id,
                       error,
                       dec.init?.callee
@@ -283,7 +286,7 @@ function getComponentHookArgs(
                   }
                 } catch (error) {
                   console.error(
-                    "err thrown when getting hook args (ExpressionStatement)",
+                    "[vite-plugin-kaioken]: err thrown when getting hook args (ExpressionStatement)",
                     id,
                     error,
                     bodyNode.expression?.callee
@@ -321,7 +324,7 @@ function transformInsertUnnamedWatchPreambles(
     }
     if (findNode(node, watchAliasHandler.nodeContainsAliasCall)) {
       const nameSet = new Set<any>()
-      addHotVarDesc(node, nameSet, "asdasdasd")
+      addHotVarDesc(node, nameSet, "unnamedWatch")
       if (nameSet.size === 0) {
         ctx.inserts.push({
           content: UNNAMED_WATCH_PREAMBLE,

--- a/sandbox/csr/src/App.tsx
+++ b/sandbox/csr/src/App.tsx
@@ -9,6 +9,8 @@ import {
   useSignal,
   signal,
   watch,
+  useWatch,
+  computed,
 } from "kaioken"
 import { SignalsExample } from "./components/SignalsExample"
 import { UseAsyncExample } from "./components/UseAsyncExample"
@@ -20,7 +22,7 @@ type AppRoute = {
 }
 
 function Counter() {
-  const count = useSignal(41)
+  const count = useSignal(1)
   const countRef = useRef<HTMLDivElement>(null)
   const animRef = useRef<Animation>()
 
@@ -49,10 +51,13 @@ function Counter() {
   )
 }
 const count = signal(1)
-watch(() => console.log("count asd", count.value))
+const triple = computed(() => count.value * 3)
+watch(() => console.log("count", count.value))
+watch(() => console.log("triple", triple.value))
 
 const Home: Kaioken.FC = () => {
-  const double = useComputed(() => count.value * 2)
+  const double = useComputed(() => count.value * 32)
+  useWatch(() => console.log("inner triple b", triple.value))
 
   return (
     <div>


### PR DESCRIPTION
This update deprecates our previous hook invalidation behavior where all relevant arguments would be serialized during runtime and compared upon HMR-triggered updates. The new implementation involves reading raw text from the file, finding hook calls and their args, encoding the arguments and providing this along with the component ref to HMRContext. We are then able to diff the serialized _raw args_ across HMR-triggered updates, allowing for a pretty nice perf win and better DX.