### PR TITLE
Lazy hmr

### DIFF
--- a/packages/lib/src/lazy.ts
+++ b/packages/lib/src/lazy.ts
@@ -1,10 +1,14 @@
+import { $HMR_ACCEPT } from "./constants.js"
 import { createElement } from "./element.js"
+import { __DEV__ } from "./env.js"
 import { renderMode } from "./globals.js"
+import { HMRAccept } from "./hmr.js"
 import { useRequestUpdate } from "./hooks/utils.js"
+import { traverseApply } from "./utils.js"
 
 type FCModule = { default: Kaioken.FC<any> }
 type LazyImportValue = Kaioken.FC<any> | FCModule
-type InferProps<T extends LazyImportValue> = T extends FCModule
+type InferLazyImportProps<T extends LazyImportValue> = T extends FCModule
   ? Kaioken.InferProps<T["default"]>
   : Kaioken.InferProps<T>
 
@@ -13,30 +17,36 @@ type LazyState = {
   result: Kaioken.FC | null
 }
 
-type LazyComponentProps<T extends LazyImportValue> = InferProps<T> & {
+type LazyComponentProps<T extends LazyImportValue> = InferLazyImportProps<T> & {
   fallback?: JSX.Element
 }
 
-const lazyCache = new WeakMap<() => Promise<LazyImportValue>, LazyState>()
+const lazyCache: Map<string, LazyState> =
+  "window" in globalThis
+    ? // @ts-ignore - we're shamefully polluting the global scope here and hiding it 🥲
+      (window.__KAIOKEN_LAZY_CACHE ??= new Map<string, LazyState>())
+    : new Map<string, LazyState>()
 
 export function lazy<T extends LazyImportValue>(
-  componentPromise: () => Promise<T>
+  componentPromiseFn: () => Promise<T>
 ): Kaioken.FC<LazyComponentProps<T>> {
   function LazyComponent(props: LazyComponentProps<T>) {
     const { fallback = null, ...rest } = props
+    const requestUpdate = useRequestUpdate()
     if (renderMode.current === "string" || renderMode.current === "stream") {
       return fallback
     }
-    const requestUpdate = useRequestUpdate()
-    const cachedState = lazyCache.get(componentPromise)
+
+    const asStr = cleanFnStr(componentPromiseFn.toString())
+    const cachedState = lazyCache.get(asStr)
 
     if (!cachedState) {
-      const promise = componentPromise()
+      const promise = componentPromiseFn()
       const state: LazyState = {
         promise,
         result: null,
       }
-      lazyCache.set(componentPromise, state)
+      lazyCache.set(asStr, state)
       promise.then((componentOrModule) => {
         state.result =
           typeof componentOrModule === "function"
@@ -51,8 +61,36 @@ export function lazy<T extends LazyImportValue>(
       cachedState.promise.then(requestUpdate)
       return fallback
     }
+    if (__DEV__) {
+      return createElement(cachedState.result, rest)
+    }
     return createElement(cachedState.result, rest)
   }
   LazyComponent.displayName = "Kaioken.lazy"
+  if (__DEV__) {
+    return Object.assign(LazyComponent, {
+      [$HMR_ACCEPT]: {
+        inject: (prev) => {
+          window.__kaioken!.apps.forEach((ctx) => {
+            if (!ctx.mounted || !ctx.rootNode) return
+            traverseApply(ctx.rootNode, (vNode) => {
+              if (vNode.type === prev) {
+                vNode.type = LazyComponent
+                vNode.hmrUpdated = true
+                if (vNode.prev) {
+                  vNode.prev.type = LazyComponent
+                }
+                ctx.requestUpdate(vNode)
+              }
+            })
+          })
+        },
+        destroy: () => {},
+        provide: () => LazyComponent,
+      } satisfies HMRAccept<Function>,
+    })
+  }
   return LazyComponent
 }
+
+const cleanFnStr = (fnStr: string) => fnStr.replace(/\?[^"]*/, "")

--- a/packages/vite-plugin-kaioken/src/codegen.ts
+++ b/packages/vite-plugin-kaioken/src/codegen.ts
@@ -126,10 +126,11 @@ function createAliasHandler(name: string) {
   const nodeContainsAliasCall = (node: AstNode) =>
     node.type === "CallExpression" &&
     node.callee?.type === "Identifier" &&
-    aliases.has(node.callee.name ?? "_not_found_")
+    typeof node.callee.name === "string" &&
+    aliases.has(node.callee.name)
 
   const addAliases = (node: AstNode) => {
-    if (!node.source || node.source.value !== "kaioken") return
+    if (node.source?.value !== "kaioken") return
     const specifiers = node.specifiers || []
     for (let i = 0; i < specifiers.length; i++) {
       const specifier = specifiers[i]
@@ -154,6 +155,7 @@ function findHotVars(nodes: AstNode[], _id: string): Set<HotVarDesc> {
     "computed",
     "watch",
     "createContext",
+    "lazy",
   ].map((name) => createAliasHandler(name))
 
   for (const node of nodes) {

--- a/sandbox/csr/src/App.tsx
+++ b/sandbox/csr/src/App.tsx
@@ -2,7 +2,6 @@ import {
   Router,
   Route,
   Link,
-  lazy,
   useRef,
   useCallback,
   useComputed,
@@ -12,14 +11,7 @@ import {
   useWatch,
   computed,
 } from "kaioken"
-import { SignalsExample } from "./components/SignalsExample"
-import { UseAsyncExample } from "./components/UseAsyncExample"
-
-type AppRoute = {
-  title: string
-  component: Kaioken.FC<any>
-  fallthrough?: boolean
-}
+import { ROUTES } from "./routes"
 
 function Counter() {
   const count = useSignal(1)
@@ -75,97 +67,11 @@ const Home: Kaioken.FC = () => {
   )
 }
 
-const ROUTES: Record<string, AppRoute> = {
-  "/": {
-    title: "Home",
-    component: Home,
-  },
-  "/keyed-list-example": {
-    title: "Keyed list",
-    component: lazy(() =>
-      import("./components/KeyedListExample").then((m) => m.KeyedListExample)
-    ),
-  },
-  "/filtered-list-example": {
-    title: "Filtered list",
-    component: lazy(() =>
-      import("./components/FilteredListExample").then(
-        (m) => m.FilteredListExample
-      )
-    ),
-  },
-  "/big-list-example": {
-    title: "Big list",
-    component: lazy(() =>
-      import("./components/BigListExample").then((m) => m.BigListExample)
-    ),
-  },
-  "/context-example": {
-    title: "Context",
-    component: lazy(() =>
-      import("./components/ContextExample").then((m) => m.ContextExample)
-    ),
-  },
-  "/use-model-example": {
-    title: "useModel",
-    component: lazy(() =>
-      import("./components/UseModelExample").then((m) => m.UseModelExample)
-    ),
-  },
-  "/memo-example": {
-    title: "Memo",
-    component: lazy(() =>
-      import("./components/MemoExample").then((m) => m.MemoExample)
-    ),
-  },
-  "/router-example": {
-    title: "Router",
-    component: lazy(() =>
-      import("./components/RouterExample").then((m) => m.RouterExample)
-    ),
-    fallthrough: true,
-  },
-  "/signals-example": {
-    title: "Signals",
-    component: SignalsExample,
-    // component: lazy(() =>
-    //   import("./components/SignalsExample").then((m) => m.SignalsExample)
-    // ),
-    fallthrough: true,
-  },
-  "/store-example": {
-    title: "Store",
-    component: lazy(() =>
-      import("./components/StoreExample").then((m) => m.StoreExample)
-    ),
-  },
-  "/transitions-example": {
-    title: "Transitions",
-    component: lazy(() =>
-      import("./components/TransitionsExample").then(
-        (m) => m.TransitionsExample
-      )
-    ),
-  },
-  "/use-async-example": {
-    title: "useAsync",
-    component: UseAsyncExample,
-    // component: lazy(() =>
-    //   import("./components/UseAsyncExample").then((m) => m.UseAsyncExample)
-    // ),
-  },
-  "/use-sync-external-store-example": {
-    title: "useSyncExternalStore",
-    component: lazy(() => import("./components/UseSyncExternalStoreExample")),
-  },
-}
-
-console.log("ROUTES", ROUTES)
-
 function Nav() {
   return (
     <nav className=" min-h-screen p-2  mb-5 h-full">
       <div className="sticky top-0 flex flex-col gap-2">
+        <Link to={"/"}>Home</Link>
         {Object.entries(ROUTES).map(([path, route]) => (
           <Link key={route.title} to={path}>
             {route.title}
@@ -183,6 +89,7 @@ export function App() {
       <Nav />
       <main className="flex items-center justify-center flex-grow w-full">
         <Router>
+          <Route path="/" element={<Home />} />
           {Object.entries(ROUTES).map(([path, route]) => (
             <Route
               key={path}

--- a/sandbox/csr/src/components/BigListExample.tsx
+++ b/sandbox/csr/src/components/BigListExample.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useState } from "kaioken"
 
-export function BigListExample() {
+export default function BigListExample() {
   const [toggle, setToggle] = useState(false)
 
   let startTime = performance.now()

--- a/sandbox/csr/src/components/ContextExample.tsx
+++ b/sandbox/csr/src/components/ContextExample.tsx
@@ -5,7 +5,7 @@ ThemeContext.displayName = "ThemeContext"
 const ThemeContextDispatcher = createContext<() => void>(() => {})
 ThemeContextDispatcher.displayName = "ThemeContextDispatcher"
 
-export function ContextExample() {
+export default function ContextExample() {
   const [themeA, setThemeA] = useState<"light" | "dark">("light")
   const [themeB, setThemeB] = useState<"light" | "dark">("light")
   return (

--- a/sandbox/csr/src/components/FilteredListExample.tsx
+++ b/sandbox/csr/src/components/FilteredListExample.tsx
@@ -40,7 +40,7 @@ const albums: Album[] = [
   },
 ]
 
-export function FilteredListExample() {
+export default function FilteredListExample() {
   const [sort, setSort] = useState<"asc" | "desc">("asc")
   const [inputRef, inputValue] = useModel<HTMLInputElement>("")
   useEffect(() => {

--- a/sandbox/csr/src/components/KeyedListExample.tsx
+++ b/sandbox/csr/src/components/KeyedListExample.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useState } from "kaioken"
 import { Button } from "./atoms/Button"
 
-export function KeyedListExample() {
+export default function KeyedListExample() {
   const [counters, setCounters] = useState<number[]>([1, 2, 3, 4, 5])
 
   function move(id: number, dist: number) {

--- a/sandbox/csr/src/components/MemoExample.tsx
+++ b/sandbox/csr/src/components/MemoExample.tsx
@@ -3,7 +3,7 @@ import { Button } from "./atoms/Button"
 
 const count = signal(0)
 
-export function MemoExample() {
+export default function MemoExample() {
   return (
     <div id="memo">
       <span>Count: {count.value}</span>

--- a/sandbox/csr/src/components/RouterExample.tsx
+++ b/sandbox/csr/src/components/RouterExample.tsx
@@ -1,6 +1,6 @@
 import { useState, useRouter, Link, Router, Route } from "kaioken"
 
-export function RouterExample() {
+export default function RouterExample() {
   const [count, setCount] = useState(0)
   const {
     params,

--- a/sandbox/csr/src/components/SignalsExample.tsx
+++ b/sandbox/csr/src/components/SignalsExample.tsx
@@ -29,7 +29,7 @@ const watcher = watch(() => {
   console.log("count 123", count.value)
 })
 
-export function SignalsExample() {
+export default function SignalsExample() {
   return (
     <div>
       <nav className="flex gap-2 bg-transparent">

--- a/sandbox/csr/src/components/StoreExample/index.tsx
+++ b/sandbox/csr/src/components/StoreExample/index.tsx
@@ -1,6 +1,6 @@
 import { useTodosStore, TodoItem as TodoItemType } from "./store"
 
-export function StoreExample() {
+export default function StoreExample() {
   const { value: todos } = useTodosStore(
     (store) => store,
     (prev, next) => prev.length === next.length

--- a/sandbox/csr/src/components/TransitionsExample/index.tsx
+++ b/sandbox/csr/src/components/TransitionsExample/index.tsx
@@ -1,7 +1,7 @@
 import { DrawerDemo } from "./Drawer"
 import { ModalDemo } from "./Modal"
 
-export const TransitionsExample = () => {
+export default function TransitionsExample() {
   return (
     <div className="flex gap-2">
       <ModalDemo />

--- a/sandbox/csr/src/components/UseAsyncExample.tsx
+++ b/sandbox/csr/src/components/UseAsyncExample.tsx
@@ -16,7 +16,7 @@ interface Product {
   images: string[]
 }
 
-export function UseAsyncExample() {
+export default function UseAsyncExample() {
   const [count, setCount] = useState(0)
   const [productId, setProductId] = useState(1)
   const { data, loading, error, invalidate } = useAsync<Product>(

--- a/sandbox/csr/src/components/useModelExample.tsx
+++ b/sandbox/csr/src/components/useModelExample.tsx
@@ -1,6 +1,6 @@
 import { useModel } from "kaioken"
 
-export function UseModelExample() {
+export default function UseModelExample() {
   return (
     <div className="flex flex-col gap-2">
       <ModelInputText />

--- a/sandbox/csr/src/routes.ts
+++ b/sandbox/csr/src/routes.ts
@@ -1,0 +1,77 @@
+import { lazy } from "kaioken"
+
+type AppRoute = {
+  title: string
+  component: Kaioken.FC<any>
+  fallthrough?: boolean
+}
+
+const KeyedListExample = lazy(() => import("./components/KeyedListExample"))
+const FilteredListExample = lazy(
+  () => import("./components/FilteredListExample")
+)
+const BigListExample = lazy(() => import("./components/BigListExample"))
+const ContextExample = lazy(() => import("./components/ContextExample"))
+const UseModelExample = lazy(() => import("./components/UseModelExample"))
+const MemoExample = lazy(() => import("./components/MemoExample"))
+const RouterExample = lazy(() => import("./components/RouterExample"))
+const SignalsExample = lazy(() => import("./components/SignalsExample"))
+const StoreExample = lazy(() => import("./components/StoreExample"))
+const TransitionsExample = lazy(() => import("./components/TransitionsExample"))
+const UseAsyncExample = lazy(() => import("./components/UseAsyncExample"))
+const UseSyncExternalStoreExample = lazy(
+  () => import("./components/UseSyncExternalStoreExample")
+)
+
+export const ROUTES: Record<string, AppRoute> = {
+  "/keyed-list-example": {
+    title: "Keyed list",
+    component: KeyedListExample,
+  },
+  "/filtered-list-example": {
+    title: "Filtered list",
+    component: FilteredListExample,
+  },
+  "/big-list-example": {
+    title: "Big list",
+    component: BigListExample,
+  },
+  "/context-example": {
+    title: "Context",
+    component: ContextExample,
+  },
+  "/use-model-example": {
+    title: "useModel",
+    component: UseModelExample,
+  },
+  "/memo-example": {
+    title: "Memo",
+    component: MemoExample,
+  },
+  "/router-example": {
+    title: "Router",
+    component: RouterExample,
+    fallthrough: true,
+  },
+  "/signals-example": {
+    title: "Signals",
+    component: SignalsExample,
+    fallthrough: true,
+  },
+  "/store-example": {
+    title: "Store",
+    component: StoreExample,
+  },
+  "/transitions-example": {
+    title: "Transitions",
+    component: TransitionsExample,
+  },
+  "/use-async-example": {
+    title: "useAsync",
+    component: UseAsyncExample,
+  },
+  "/use-sync-external-store-example": {
+    title: "useSyncExternalStore",
+    component: UseSyncExternalStoreExample,
+  },
+}


### PR DESCRIPTION
This PR implements formal HMR support for components loaded via `lazy`. Includes improvements to vite-plugin-kaioken's codegen, AST crawling and component/variable declaration resolution