### PR TITLE
Memo <-> context rework

### DIFF
--- a/e2e/cypress/e2e/memo.cy.ts
+++ b/e2e/cypress/e2e/memo.cy.ts
@@ -22,6 +22,34 @@ describe("component memoization", () => {
     )
   })
 
+  it("allows deep context consumers that are memoized to rerender", () => {
+    cy.get("main #memo div[data-memo-depth]").each((element) => {
+      cy.wrap(element).should("have.attr", "data-renders", "1")
+    })
+    cy.get("main #memo #memo-deep-context-consumer span").should(
+      "have.text",
+      "Render Count: 1"
+    )
+    cy.get("main #memo > button").click().click()
+    cy.get("main #memo #memo-deep-context-consumer span").should(
+      "have.text",
+      "Render Count: 3"
+    )
+    cy.get("main #memo div[data-memo-depth]").each((element) => {
+      cy.wrap(element).should("have.attr", "data-renders", "1")
+    })
+    // cy.get("main #memo div[data-memo-depth='1']").should(
+    //   "have.attr",
+    //   "data-memo-renders",
+    //   "1"
+    // )
+    // cy.get("main #memo div[data-memo-depth='2']").should(
+    //   "have.attr",
+    //   "data-memo-renders",
+    //   "1"
+    // )
+  })
+
   it("will render as per normal when included / excluded from the vDom tree", () => {
     cy.get("main #memo #memo-dynamic > span:first-child").should(
       "have.text",

--- a/e2e/cypress/e2e/memo.cy.ts
+++ b/e2e/cypress/e2e/memo.cy.ts
@@ -10,14 +10,38 @@ describe("component memoization", () => {
     cy.get("main #memo #memo-props span").should("have.text", "Render Count: 1")
   })
 
+  it("allows context consumers that are memoized to rerender", () => {
+    cy.get("main #memo #memo-context-consumer span").should(
+      "have.text",
+      "Render Count: 1"
+    )
+    cy.get("main #memo > button").click().click()
+    cy.get("main #memo #memo-context-consumer span").should(
+      "have.text",
+      "Render Count: 3"
+    )
+  })
+
   it("will render as per normal when included / excluded from the vDom tree", () => {
+    cy.get("main #memo #memo-dynamic > span:first-child").should(
+      "have.text",
+      "Render Count: 1"
+    )
     cy.get("main #memo > button").click()
     cy.get("main #memo #memo-dynamic").should("not.exist")
     cy.get("main #memo > button").click()
     cy.get("main #memo #memo-dynamic").should("exist")
+    cy.get("main #memo #memo-dynamic > span:first-child").should(
+      "have.text",
+      "Render Count: 2"
+    )
     cy.get("main #memo > button").click()
     cy.get("main #memo #memo-dynamic").should("not.exist")
     cy.get("main #memo > button").click()
     cy.get("main #memo #memo-dynamic").should("exist")
+    cy.get("main #memo #memo-dynamic > span:first-child").should(
+      "have.text",
+      "Render Count: 3"
+    )
   })
 })

--- a/e2e/src/MemoTest.tsx
+++ b/e2e/src/MemoTest.tsx
@@ -78,15 +78,13 @@ const memoNodeRenders = new Map<number, number>([
 ])
 const MemoNode: Kaioken.FC<{ depth: number }> = memo(
   function MemoNode({ children, depth }) {
-    memoNodeRenders.set(depth, memoNodeRenders.get(depth)! + 1)
+    const renders = memoNodeRenders.get(depth)! + 1
+    memoNodeRenders.set(depth, renders)
     return (
-      <div
-        data-memo-depth={depth}
-        data-memo-renders={memoNodeRenders.get(depth)!}
-      >
+      <div data-memo-depth={depth} data-renders={renders}>
         {children}
       </div>
     )
-  }
-  //() => true
+  },
+  () => true
 )

--- a/e2e/src/MemoTest.tsx
+++ b/e2e/src/MemoTest.tsx
@@ -1,4 +1,11 @@
-import { memo, signal, useState } from "kaioken"
+import { createContext, memo, useContext, useState } from "kaioken"
+
+type CountContextType = {
+  count: number
+  setCount: (count: Kaioken.StateSetter<number>) => void
+}
+const CountContext = createContext<CountContextType>(null!)
+const useCount = () => useContext(CountContext)
 
 export function MemoTest() {
   const [count, setCount] = useState(0)
@@ -6,32 +13,80 @@ export function MemoTest() {
     <div id="memo">
       <span>Count: {count}</span>
       <button onclick={() => setCount((prev) => prev + 1)}>Increment</button>
-      <WhenPropsChangeMemo count={1} />
-      {count % 2 === 0 && <DynamicRenderMemo />}
+      <PropsChangedMemo count={1} />
+      {count % 2 === 0 && <ToggledMemo />}
+      <CountContext.Provider value={{ count, setCount }}>
+        <ContextConsumerMemo />
+
+        <MemoNode depth={0}>
+          <MemoNode depth={1}>
+            <MemoNode depth={2}>
+              <ContextConsumerMemo id="memo-deep-context-consumer" />
+            </MemoNode>
+          </MemoNode>
+        </MemoNode>
+      </CountContext.Provider>
     </div>
   )
 }
 
-let renders = 0
-const WhenPropsChangeMemo = memo(({ count }: { count: number }) => {
+let propsChangedRenders = 0
+const PropsChangedMemo = memo(({ count }: { count: number }) => {
   return (
     <div id="memo-props" className="flex flex-col">
       <div>Memo Demo {count}</div>
-      <span>Render Count: {++renders}</span>
+      <span>Render Count: {++propsChangedRenders}</span>
     </div>
   )
 })
 
-const renders2 = signal(0)
-const DynamicRenderMemo = memo(() => {
-  const [count, setCount] = useState(123)
-  const r = renders2.peek()
-  renders2.sneak(renders2.peek() + 1)
+let toggledRenders = 0
+const ToggledMemo = memo(function MemoDynamic() {
   return (
     <div id="memo-dynamic" className="flex flex-col">
-      <span className="text-red-500">Render Count: {r}</span>
-      <span>Count: {count}</span>
-      <button onclick={() => setCount((prev) => prev + 1)}>Increment</button>
+      <span>Render Count: {++toggledRenders}</span>
     </div>
   )
 })
+
+let contextConsumerRenders = new Map<string, number>([])
+const ContextConsumerMemo = memo(function MemoContextConsumer({
+  id = "memo-context-consumer",
+}: {
+  id?: string
+}) {
+  const { count, setCount } = useCount()
+  if (!contextConsumerRenders.has(id)) {
+    contextConsumerRenders.set(id, 1)
+  } else {
+    contextConsumerRenders.set(id, contextConsumerRenders.get(id)! + 1)
+  }
+  return (
+    <div id={id}>
+      <button onclick={() => setCount((prev) => prev + 1)}>
+        Increment: {count}
+      </button>
+      <span>Render Count: {contextConsumerRenders.get(id)}</span>
+    </div>
+  )
+})
+
+const memoNodeRenders = new Map<number, number>([
+  [0, 0],
+  [1, 0],
+  [2, 0],
+])
+const MemoNode: Kaioken.FC<{ depth: number }> = memo(
+  function MemoNode({ children, depth }) {
+    memoNodeRenders.set(depth, memoNodeRenders.get(depth)! + 1)
+    return (
+      <div
+        data-memo-depth={depth}
+        data-memo-renders={memoNodeRenders.get(depth)!}
+      >
+        {children}
+      </div>
+    )
+  }
+  //() => true
+)

--- a/packages/devtools-client/src/utils.ts
+++ b/packages/devtools-client/src/utils.ts
@@ -1,4 +1,4 @@
-import { isFragment, isLazy } from "../../lib/dist/utils.js"
+import { isFragment, isLazy, isMemo } from "../../lib/dist/utils.js"
 
 export function getNodeName(node: Kaioken.VNode) {
   return (
@@ -15,7 +15,12 @@ export function searchMatchesItem(terms: string[], item: string) {
 export function isComponent(
   node: Kaioken.VNode
 ): node is Kaioken.VNode & { type: Function } {
-  return typeof node.type === "function" && !isFragment(node) && !isLazy(node)
+  return (
+    typeof node.type === "function" &&
+    !isFragment(node) &&
+    !isLazy(node) &&
+    !isMemo(node)
+  )
 }
 
 export function nodeContainsComponent(node: Kaioken.VNode) {

--- a/packages/lib/src/constants.ts
+++ b/packages/lib/src/constants.ts
@@ -12,6 +12,7 @@ export const FLAG = {
   UPDATE: 1,
   PLACEMENT: 2,
   DELETION: 3,
+  HAS_MEMO_ANCESTOR: 4,
 } as const
 
 export const ELEMENT_TYPE = {

--- a/packages/lib/src/context.ts
+++ b/packages/lib/src/context.ts
@@ -2,15 +2,17 @@ import { $CONTEXT, $CONTEXT_PROVIDER, $HMR_ACCEPT } from "./constants.js"
 import { createElement } from "./element.js"
 import { __DEV__ } from "./env.js"
 import { GenericHMRAcceptor } from "./hmr.js"
+import { useState } from "./hooks/useState.js"
 import { traverseApply } from "./utils.js"
 
 export function createContext<T>(defaultValue: T): Kaioken.Context<T> {
   const ctx: Kaioken.Context<T> = {
     [$CONTEXT]: true,
     Provider: ({ value, children }: Kaioken.ProviderProps<T>) => {
+      const [dependents] = useState(() => new Set<Kaioken.VNode>())
       return createElement(
         $CONTEXT_PROVIDER,
-        { value, ctx },
+        { value, ctx, dependents },
         typeof children === "function" ? children(value) : children
       )
     },

--- a/packages/lib/src/element.ts
+++ b/packages/lib/src/element.ts
@@ -1,4 +1,5 @@
-import { $FRAGMENT } from "./constants.js"
+import { $FRAGMENT, $MEMO } from "./constants.js"
+import { isMemoFn } from "./memo.js"
 import { isValidElementKeyProp, isValidElementRefProp } from "./props.js"
 
 export function createElement<T extends Kaioken.VNode["type"]>(
@@ -15,6 +16,10 @@ export function createElement<T extends Kaioken.VNode["type"]>(
     index: 0,
     depth: 0,
     props: {},
+  }
+  if (isMemoFn(type)) {
+    node.isMemoized = true
+    node.arePropsEqual = type[$MEMO].arePropsEqual
   }
 
   if (props !== null) {

--- a/packages/lib/src/flags.ts
+++ b/packages/lib/src/flags.ts
@@ -7,4 +7,9 @@ export const flags = {
   get(field: number, n: number): boolean {
     return (field & (1 << n)) !== 0
   },
+  // Unset all flags between `start` and `end`
+  unsetRange(field: number, start: number, end: number): number {
+    const mask = ((1 << (end - start + 1)) - 1) << start
+    return field & ~mask
+  },
 } as const

--- a/packages/lib/src/hooks/useContext.ts
+++ b/packages/lib/src/hooks/useContext.ts
@@ -47,9 +47,12 @@ const useContextCallback = <T>({
     while (n) {
       if (n.type === $CONTEXT_PROVIDER) {
         const ctxNode = n as ContextProviderNode<T>
-        if (ctxNode.props.ctx === hook.context) {
+        const { ctx, value, dependents } = ctxNode.props
+        if (ctx === hook.context) {
+          dependents.add(vNode)
+          hook.cleanup = () => dependents.delete(vNode)
           hook.ctxNode = ctxNode
-          return hook.ctxNode.props.value
+          return value
         }
       }
       n = n.parent

--- a/packages/lib/src/memo.ts
+++ b/packages/lib/src/memo.ts
@@ -1,4 +1,5 @@
 import { $MEMO } from "./constants.js"
+import { createElement } from "./element.js"
 import { __DEV__ } from "./env.js"
 
 function _arePropsEqual<T extends Record<string, unknown>>(
@@ -27,9 +28,15 @@ export function memo<T extends Record<string, unknown> = {}>(
   fn: Kaioken.FC<T>,
   arePropsEqual: (prevProps: T, nextProps: T) => boolean = _arePropsEqual
 ): (props: T) => JSX.Element {
-  return Object.assign(fn, {
-    [$MEMO]: { arePropsEqual },
-  })
+  return Object.assign(
+    function Memo(props: T) {
+      return createElement(fn, props)
+    },
+    {
+      [$MEMO]: { arePropsEqual },
+      displayName: "Kaioken.memo",
+    }
+  )
 }
 
 export function isMemoFn(fn: any): fn is MemoFn {

--- a/packages/lib/src/reconciler.ts
+++ b/packages/lib/src/reconciler.ts
@@ -7,6 +7,14 @@ import { createElement, Fragment } from "./element.js"
 import { flags } from "./flags.js"
 import { ctx } from "./globals.js"
 
+function setParent(node: Kaioken.VNode, parent: Kaioken.VNode) {
+  node.parent = parent
+  node.depth = parent.depth + 1
+  if (parent.isMemoized || flags.get(parent.flags, FLAG.HAS_MEMO_ANCESTOR)) {
+    node.flags = flags.set(node.flags, FLAG.HAS_MEMO_ANCESTOR)
+  }
+}
+
 type VNode = Kaioken.VNode
 
 function emitUpdateNode() {
@@ -221,8 +229,7 @@ function updateTextNode(
       emitCreateNode()
     }
     const newNode = createElement(ELEMENT_TYPE.text, { nodeValue: content })
-    newNode.parent = parent
-    newNode.depth = parent.depth! + 1
+    setParent(newNode, parent)
     return newNode
   } else {
     if (__DEV__) {
@@ -266,8 +273,7 @@ function updateNode(parent: VNode, oldNode: VNode | null, newNode: VNode) {
     emitCreateNode()
   }
   const created = createElement(nodeType, newNode.props)
-  created.parent = parent
-  created.depth = parent.depth + 1
+  setParent(created, parent)
   return created
 }
 
@@ -282,8 +288,7 @@ function updateFragment(
       emitCreateNode()
     }
     const el = createElement($FRAGMENT, { children, ...newProps })
-    el.parent = parent
-    el.depth = parent.depth + 1
+    setParent(el, parent)
     return el
   }
   if (__DEV__) {
@@ -307,8 +312,7 @@ function createChild(parent: VNode, child: unknown): VNode | null {
     const el = createElement(ELEMENT_TYPE.text, {
       nodeValue: "" + child,
     })
-    el.parent = parent
-    el.depth = parent.depth + 1
+    setParent(el, parent)
     return el
   }
 
@@ -319,8 +323,7 @@ function createChild(parent: VNode, child: unknown): VNode | null {
     const el = createElement(ELEMENT_TYPE.text, {
       nodeValue: child,
     })
-    el.parent = parent
-    el.depth = parent.depth + 1
+    setParent(el, parent)
     return el
   }
 
@@ -329,8 +332,7 @@ function createChild(parent: VNode, child: unknown): VNode | null {
       emitCreateNode()
     }
     const newNode = createElement(child.type, child.props)
-    newNode.parent = parent
-    newNode.depth = parent.depth! + 1
+    setParent(newNode, parent)
     newNode.flags = flags.set(newNode.flags, FLAG.PLACEMENT)
     if ("memoizedProps" in child) newNode.memoizedProps = child.memoizedProps
     return newNode
@@ -341,8 +343,7 @@ function createChild(parent: VNode, child: unknown): VNode | null {
       emitCreateNode()
     }
     const el = Fragment({ children: child })
-    el.parent = parent
-    el.depth = parent.depth + 1
+    setParent(el, parent)
     return el
   }
 
@@ -404,8 +405,7 @@ function updateFromMap(
     const n = createElement(ELEMENT_TYPE.text, {
       nodeValue: newChild,
     })
-    n.parent = parent
-    n.depth = parent.depth + 1
+    setParent(n, parent)
     n.flags = flags.set(n.flags, FLAG.PLACEMENT)
     n.index = index
     return n
@@ -431,8 +431,7 @@ function updateFromMap(
         emitCreateNode()
       }
       const n = createElement(newChild.type, newChild.props)
-      n.parent = parent
-      n.depth = parent.depth + 1
+      setParent(n, parent)
       n.flags = flags.set(n.flags, FLAG.PLACEMENT)
       n.index = index
       return n
@@ -453,8 +452,7 @@ function updateFromMap(
         emitCreateNode()
       }
       const n = Fragment({ children: newChild })
-      n.parent = parent
-      n.depth = parent.depth + 1
+      setParent(n, parent)
       n.flags = flags.set(n.flags, FLAG.PLACEMENT)
       n.index = index
       return n

--- a/packages/lib/src/scheduler.ts
+++ b/packages/lib/src/scheduler.ts
@@ -1,7 +1,7 @@
 import type { AppContext } from "./appContext"
 import type { FunctionVNode } from "./types.utils"
 import { flags } from "./flags.js"
-import { $MEMO, CONSECUTIVE_DIRTY_LIMIT, FLAG } from "./constants.js"
+import { CONSECUTIVE_DIRTY_LIMIT, FLAG } from "./constants.js"
 import { commitWork, createDom, hydrateDom } from "./dom.js"
 import { __DEV__ } from "./env.js"
 import { KaiokenError } from "./error.js"
@@ -10,7 +10,6 @@ import { hydrationStack } from "./hydration.js"
 import { assertValidElementProps } from "./props.js"
 import { reconcileChildren } from "./reconciler.js"
 import { isExoticVNode, latest, traverseApply, vNodeContains } from "./utils.js"
-import { isMemoFn } from "./memo.js"
 import { Signal } from "./signals/base.js"
 
 type VNode = Kaioken.VNode
@@ -337,12 +336,19 @@ export class Scheduler {
   }
 
   private updateFunctionComponent(vNode: FunctionVNode) {
-    const { type, props, subs, prev, child: prevChild = null } = vNode
-    if (isMemoFn(type)) {
+    const {
+      type,
+      props,
+      subs,
+      prev,
+      child: prevChild = null,
+      isMemoized,
+    } = vNode
+    if (isMemoized) {
       vNode.memoizedProps = props
       if (
         prev?.memoizedProps &&
-        type[$MEMO].arePropsEqual(prev.memoizedProps, props) &&
+        vNode.arePropsEqual!(prev.memoizedProps, props) &&
         !vNode.hmrUpdated
       ) {
         return false

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -205,7 +205,11 @@ declare global {
       prevStyleObj?: StyleObject
       hmrUpdated?: boolean
       memoizedProps?: Record<string, any>
-      boundAttrs?: Record<string, any>
+      isMemoized?: boolean
+      arePropsEqual?: (
+        prev: Record<string, any>,
+        next: Record<string, any>
+      ) => boolean
     }
   }
 

--- a/packages/lib/src/types.utils.ts
+++ b/packages/lib/src/types.utils.ts
@@ -16,7 +16,7 @@ export type DomVNode = VNode & { dom: SomeDom }
 
 export type ContextProviderNode<T> = Kaioken.VNode & {
   type: typeof $CONTEXT_PROVIDER
-  props: { value: T; ctx: Kaioken.Context<T> }
+  props: { value: T; ctx: Kaioken.Context<T>; dependents: Set<Kaioken.VNode> }
 }
 
 export type Prettify<T> = {

--- a/sandbox/csr/dev.js
+++ b/sandbox/csr/dev.js
@@ -30,6 +30,6 @@ if (process.argv.includes("--child")) {
       console.log("Restarting server due to plugin change...")
       child.kill()
       child = createChild()
-    })
+    }, 50)
   })
 }

--- a/sandbox/csr/src/App.tsx
+++ b/sandbox/csr/src/App.tsx
@@ -1,48 +1,10 @@
-import { useSignal, useComputed, For, Derive } from "kaioken"
 import { Router, Route, Link } from "kaioken/router"
 import { ROUTES } from "./routes"
-
-function ForExample() {
-  const items = useSignal([0, 1, 2, 3, 4])
-  const doubledItems = useComputed(() => items.value.map((i) => i * 2))
-  return (
-    <>
-      <ul>
-        <For each={doubledItems}>{(item) => <li>{item}</li>}</For>
-      </ul>
-      <button
-        onclick={() => (items.value = [...items.value, items.value.length])}
-      >
-        Add
-      </button>
-    </>
-  )
-}
-
-function DeriveExample() {
-  const name = useSignal("bob")
-  const age = useSignal(42)
-  const person = useComputed(() => ({ name: name.value, age: age.value }))
-  return (
-    <div>
-      <input bind:value={name} />
-      <input type="number" bind:value={age} />
-      <Derive from={person}>
-        {(person) => (
-          <div>
-            {person.name} is {person.age} years old
-          </div>
-        )}
-      </Derive>
-    </div>
-  )
-}
 
 const Home: Kaioken.FC = () => {
   return (
     <div>
-      <ForExample />
-      <DeriveExample />
+      <h1>Home</h1>
     </div>
   )
 }

--- a/sandbox/csr/src/components/ContextExample.tsx
+++ b/sandbox/csr/src/components/ContextExample.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from "kaioken"
+import { createContext, memo, useContext, useState } from "kaioken"
 
 const ThemeContext = createContext<"light" | "dark">("dark")
 ThemeContext.displayName = "ThemeContext"
@@ -34,9 +34,10 @@ export default function ContextExample() {
     </div>
   )
 }
-
-function ThemeButton() {
+// When a component uses a context, the provider is registered as a dependency.
+// This allows us to ensure that even despite being memoized, the component will re-render when the context changes.
+const ThemeButton = memo(function ThemeButton() {
   const theme = useContext(ThemeContext)
   const dispatch = useContext(ThemeContextDispatcher)
   return <button onclick={() => dispatch()}>{theme}</button>
-}
+})

--- a/sandbox/csr/src/components/KeyedListExample.tsx
+++ b/sandbox/csr/src/components/KeyedListExample.tsx
@@ -1,7 +1,8 @@
-import { Fragment, useState } from "kaioken"
+import { Fragment, useAppContext, useState } from "kaioken"
 import { Button } from "./atoms/Button"
 
 export default function KeyedListExample() {
+  const appCtx = useAppContext()
   const [counters, setCounters] = useState<number[]>([1, 2, 3, 4, 5])
 
   function move(id: number, dist: number) {
@@ -10,18 +11,24 @@ export default function KeyedListExample() {
     const newCounters = [...counters]
     newCounters.splice(idx, 1)
     newCounters.splice(idx + dist, 0, id)
-    setCounters(newCounters)
+    document.startViewTransition(() => {
+      setCounters(newCounters)
+      appCtx.flushSync()
+    })
   }
 
   function remove(id: number) {
-    setCounters(counters.filter((c) => c !== id))
+    document.startViewTransition(() => {
+      setCounters(counters.filter((c) => c !== id))
+      appCtx.flushSync()
+    })
   }
 
   return (
     <ul>
       {counters.map((c) => (
         <Fragment key={"item-" + c}>
-          <li className="flex gap-2">
+          <li className="flex gap-2" style={`view-transition-name: item-${c}`}>
             <KeyedCounterItem
               id={c}
               move={(dist) => move(c, dist)}

--- a/sandbox/csr/src/components/MemoExample.tsx
+++ b/sandbox/csr/src/components/MemoExample.tsx
@@ -1,26 +1,91 @@
-import { memo, signal, useModel } from "kaioken"
-import { Button } from "./atoms/Button"
+import { createContext, memo, useContext, useState } from "kaioken"
 
-const count = signal(0)
+type CountContextType = {
+  count: number
+  setCount: (value: Kaioken.StateSetter<number>) => void
+}
+const CountContext = createContext<CountContextType>(null!)
+const useCount = () => useContext(CountContext)
 
 export default function MemoExample() {
+  const [count, setCount] = useState(0)
+  const [otherCount, setOtherCount] = useState(0)
+
+  console.log("MemoExample")
+
   return (
-    <div id="memo">
-      <span>Count: {count.value}</span>
-      <Button onclick={() => count.value++}>Increment</Button>
-      <MemoizedComponent test="test" />
-    </div>
+    <>
+      <button onclick={() => setOtherCount(otherCount + 1)}>
+        other count: {otherCount}
+      </button>
+      <CountContext.Provider value={{ count, setCount }}>
+        <Counter />
+      </CountContext.Provider>
+    </>
   )
 }
 
-// @ts-ignore
-const MemoizedComponent = memo(({ test }: { test: string }) => {
-  console.log("render MemoizedComponent")
-  const [ref, name] = useModel<HTMLInputElement>("")
+const Counter = memo(Counter_)
+
+function Counter_() {
+  console.log("Counter_")
+  return <CounterChild />
+}
+
+const CounterChild = memo(CounterChild_)
+function CounterChild_() {
+  const { count, setCount } = useCount()
+  console.log("CounterChild_")
   return (
-    <div id="memo-dynamic" className="flex flex-col">
-      <input ref={ref} type="text" />
-      <span>Name: {name}</span>
-    </div>
+    <>
+      <button onclick={() => setCount(count + 1)}>count: {count}</button>
+    </>
   )
-})
+}
+
+// import { Button } from "./atoms/Button"
+
+// const count = signal(0)
+// const name = signal("123")
+// name.subscribe((name) => console.log("name changed", name))
+
+// const NameContext = createContext("")
+
+// export default function MemoExample() {
+//   return (
+//     <div id="memo">
+//       <input bind:value={name} />
+//       <span>Count: {count.value}</span>
+//       <Button onclick={() => count.value++}>Increment</Button>
+//       <MemoizedComponent test="test" />
+//       <Derive from={name}>
+//         {(name) => (
+//           <NameContext.Provider value={name}>
+//             <MemoizedContextConsumer />
+//           </NameContext.Provider>
+//         )}
+//       </Derive>
+//     </div>
+//   )
+// }
+
+// const MemoizedComponent = memo(({ test: _test }: { test: string }) => {
+//   console.log("render MemoizedComponent")
+//   const [ref, name] = useModel<HTMLInputElement>("")
+//   return (
+//     <div id="memo-dynamic" className="flex flex-col">
+//       <input ref={ref} type="text" />
+//       <span>Name: {name}</span>
+//     </div>
+//   )
+// })
+
+// const MemoizedContextConsumer = memo(() => {
+//   console.log("render MemoizedContextConsumer")
+//   const name = useContext(NameContext)
+//   return (
+//     <div>
+//       <span>Name: {name}</span>
+//     </div>
+//   )
+// })

--- a/sandbox/csr/src/components/SignalsExample.tsx
+++ b/sandbox/csr/src/components/SignalsExample.tsx
@@ -1,4 +1,12 @@
-import { signal, computed, watch, useComputed, useSignal } from "kaioken"
+import {
+  signal,
+  computed,
+  watch,
+  useComputed,
+  useSignal,
+  For,
+  Derive,
+} from "kaioken"
 import { Route, Router, Link } from "kaioken/router"
 
 const count = signal(0, "coussdsdnt")
@@ -32,10 +40,13 @@ export default function SignalsExample() {
           Local
         </Link>
       </nav>
-      <Router>
-        <Route path="/" element={<GlobalComputedExample />} />
-        <Route path="/local" element={<LocalComputedExample />} />
-      </Router>
+      <div className="flex flex-col gap-2">
+        <Router>
+          <Route path="/" element={<GlobalComputedExample />} />
+          <Route path="/local" element={<LocalComputedExample />} />
+        </Router>
+        <SignalExoticComponents />
+      </div>
     </div>
   )
 }
@@ -110,6 +121,52 @@ const LocalComputedExample = () => {
       <button className="text-left" onclick={onSwitch}>
         Switch tracking
       </button>
+    </div>
+  )
+}
+
+function SignalExoticComponents() {
+  return (
+    <>
+      <h1 className="text-2xl">Signal Exotics</h1>
+      <ForExample />
+      <DeriveExample />
+    </>
+  )
+}
+
+function ForExample() {
+  const items = useSignal([0, 1, 2, 3, 4])
+  const doubledItems = useComputed(() => items.value.map((i) => i * 2))
+  return (
+    <>
+      <ul>
+        <For each={doubledItems}>{(item) => <li>{item}</li>}</For>
+      </ul>
+      <button
+        onclick={() => (items.value = [...items.value, items.value.length])}
+      >
+        Add
+      </button>
+    </>
+  )
+}
+
+function DeriveExample() {
+  const name = useSignal("bob")
+  const age = useSignal(42)
+  const person = useComputed(() => ({ name: name.value, age: age.value }))
+  return (
+    <div>
+      <input bind:value={name} />
+      <input type="number" bind:value={age} />
+      <Derive from={person}>
+        {(person) => (
+          <div>
+            {person.name} is {person.age} years old
+          </div>
+        )}
+      </Derive>
     </div>
   )
 }


### PR DESCRIPTION
How `memo` and `context` played together was previously an oversight - `memo` would prevent updates if props had not changed, _end of story_. 

This PR brings changes that make `context providers` treat components that 'use' the context (via `useContext`) as _subscribers_. As part of the update process, when a `context provider` is updated, its subscribers that are contained by a `memo` that would prevent them from updating are now consolidated (where possible) and queued into new update jobs.