### PR TITLE
Hooks refactor

### DIFF
--- a/packages/lib/src/dom.ts
+++ b/packages/lib/src/dom.ts
@@ -7,7 +7,6 @@ import {
   svgTags,
   postOrderApply,
 } from "./utils.js"
-import { cleanupHook } from "./hooks/utils.js"
 import { FLAG } from "./constants.js"
 import { Signal, unwrap } from "./signals/index.js"
 import { ctx, renderMode } from "./globals.js"
@@ -723,7 +722,7 @@ function commitDeletion(vNode: VNode) {
       dom,
       props: { ref },
     } = node
-    while (hooks?.length) cleanupHook(hooks.pop()!)
+    while (hooks?.length) hooks.pop()!.cleanup?.()
     subs?.forEach((sub) => Signal.unsubscribe(node, sub))
     if (cleanups) Object.values(cleanups).forEach((c) => c())
 

--- a/packages/lib/src/hooks/useAsync.ts
+++ b/packages/lib/src/hooks/useAsync.ts
@@ -67,9 +67,12 @@ export function useAsync<T>(
         func: (ctx: UseAsyncCallbackContext) => Promise<T>
       ) => void,
     },
-    ({ hook, isInit, update }) => {
+    ({ hook, isInit, isHMR, update }) => {
       if (__DEV__) {
         hook.dev = { devtools: { get: () => ({ value: hook.task }) } }
+        if (isHMR) {
+          isInit = true
+        }
       }
       if (isInit) {
         hook.cleanup = () => abortTask(hook.task)

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -11,12 +11,15 @@ export function useCallback<T extends Function>(
   deps: unknown[]
 ): T {
   if (!sideEffectsEnabled()) return callback
-  return useHook("useCallback", { callback, deps }, ({ hook }) => {
+  return useHook("useCallback", { callback, deps }, ({ hook, isHMR }) => {
     if (__DEV__) {
       hook.dev = {
         devtools: {
           get: () => ({ callback: hook.callback, dependencies: hook.deps }),
         },
+      }
+      if (isHMR) {
+        hook.deps = []
       }
     }
     if (depsRequireChange(deps, hook.deps)) {

--- a/packages/lib/src/hooks/useEffectEvent.ts
+++ b/packages/lib/src/hooks/useEffectEvent.ts
@@ -11,12 +11,6 @@ import { sideEffectsEnabled, useHook } from "./utils.js"
 export function useEffectEvent<T extends Function>(callback: T): T {
   if (!sideEffectsEnabled()) return callback
   return useHook("useEffectEvent", { callback }, ({ hook }) => {
-    if (__DEV__) {
-      hook.dev = {
-        // persist function ref so that effects referring to it will continue using the latest version
-        onRawArgsChanged: "persist",
-      }
-    }
     hook.callback = callback
     return function () {
       if (node.current) {

--- a/packages/lib/src/hooks/useLayoutEffect.ts
+++ b/packages/lib/src/hooks/useLayoutEffect.ts
@@ -20,10 +20,13 @@ export function useLayoutEffect(
   return useHook(
     "useLayoutEffect",
     { deps },
-    ({ hook, isInit, queueEffect }) => {
+    ({ hook, isInit, isHMR, queueEffect }) => {
       if (__DEV__) {
         hook.dev = {
           devtools: { get: () => ({ callback, dependencies: hook.deps }) },
+        }
+        if (isHMR) {
+          isInit = true
         }
       }
       if (isInit || depsRequireChange(deps, hook.deps)) {

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -12,12 +12,15 @@ export function useMemo<T>(factory: () => T, deps: unknown[]): T {
   return useHook(
     "useMemo",
     { deps, value: undefined as T },
-    ({ hook, isInit }) => {
+    ({ hook, isInit, isHMR }) => {
       if (__DEV__) {
         hook.dev = {
           devtools: {
             get: () => ({ value: hook.value, dependencies: hook.deps }),
           },
+        }
+        if (isHMR) {
+          isInit = true
         }
       }
       if (isInit || depsRequireChange(deps, hook.deps)) {

--- a/packages/lib/src/hooks/useReducer.ts
+++ b/packages/lib/src/hooks/useReducer.ts
@@ -16,13 +16,23 @@ export function useReducer<T, A>(
   return useHook(
     "useReducer",
     { state, dispatch: noop as (action: A) => void },
-    ({ hook, isInit, update }) => {
+    ({ hook, isInit, isHMR, update }) => {
       if (__DEV__) {
-        hook.dev = {
-          devtools: {
-            get: () => ({ value: hook.state }),
-            set: ({ value }) => (hook.state = value),
-          } satisfies Kaioken.HookDevtoolsProvisions<{ value: T }>,
+        if (isInit) {
+          hook.dev = {
+            devtools: {
+              get: () => ({ value: hook.state }),
+              set: ({ value }) => (hook.state = value),
+            } satisfies Kaioken.HookDevtoolsProvisions<{ value: T }>,
+            initialArgs: [reducer, state],
+          }
+        } else if (isHMR) {
+          const [r, s] = hook.dev!.initialArgs
+          if (r !== reducer || s !== state) {
+            hook.state = state
+            isInit = true
+            hook.dev!.initialArgs = [reducer, state]
+          }
         }
       }
       if (isInit) {

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,17 +1,5 @@
 import { __DEV__ } from "../env.js"
-import { HookCallbackState, sideEffectsEnabled, useHook } from "./utils.js"
-
-type UseCallbackState<T> = {
-  ref: { current: T }
-}
-
-export function useRef<T>(initialValue: T): Kaioken.MutableRefObject<T>
-export function useRef<T>(initialValue: T | null): Kaioken.RefObject<T>
-export function useRef<T = undefined>(): Kaioken.MutableRefObject<T | undefined>
-export function useRef<T>(initialValue?: T | null) {
-  if (!sideEffectsEnabled()) return { current: initialValue }
-  return useHook("useRef", { ref: { current: initialValue } }, useRefCallback)
-}
+import { sideEffectsEnabled, useHook } from "./utils.js"
 
 /**
  * Creates a ref object. Useful for persisting values between renders or getting
@@ -19,16 +7,33 @@ export function useRef<T>(initialValue?: T | null) {
  *
  * @see https://kaioken.dev/docs/hooks/useRef
  */
-const useRefCallback = <T>({
-  hook,
-}: HookCallbackState<UseCallbackState<T>>) => {
-  if (__DEV__) {
-    hook.dev = {
-      devtools: {
-        get: () => ({ value: hook.ref.current }),
-        set: ({ value }) => (hook.ref.current = value),
-      } satisfies Kaioken.HookDevtoolsProvisions<{ value: T }>,
+export function useRef<T>(initialValue: T): Kaioken.MutableRefObject<T>
+export function useRef<T>(initialValue: T | null): Kaioken.RefObject<T>
+export function useRef<T = undefined>(): Kaioken.MutableRefObject<T | undefined>
+export function useRef<T>(initialValue?: T | null) {
+  if (!sideEffectsEnabled()) return { current: initialValue }
+  return useHook(
+    "useRef",
+    { ref: { current: initialValue } },
+    ({ hook, isInit, isHMR }) => {
+      if (__DEV__) {
+        if (isInit) {
+          hook.dev = {
+            devtools: {
+              get: () => ({ value: hook.ref.current! }),
+              set: ({ value }) => (hook.ref.current = value),
+            } satisfies Kaioken.HookDevtoolsProvisions<{ value: T }>,
+            initialArgs: [hook.ref.current],
+          }
+        } else if (isHMR) {
+          const [v] = hook.dev!.initialArgs
+          if (v !== initialValue) {
+            hook.ref = { current: initialValue }
+            hook.dev!.initialArgs = [initialValue]
+          }
+        }
+      }
+      return hook.ref
     }
-  }
-  return hook.ref
+  )
 }

--- a/packages/lib/src/hooks/useSyncExternalStore.ts
+++ b/packages/lib/src/hooks/useSyncExternalStore.ts
@@ -31,6 +31,7 @@ export function useSyncExternalStore<T>(
     {
       state: null as T,
       unsubscribe: noop as () => void,
+      subscribe,
     },
     ({ hook, isInit, update }) => {
       if (__DEV__) {
@@ -38,8 +39,9 @@ export function useSyncExternalStore<T>(
           devtools: { get: () => ({ value: hook.state }) },
         }
       }
-      if (isInit) {
+      if (isInit || hook.subscribe !== subscribe) {
         hook.state = getState()
+        hook.subscribe = subscribe
         hook.unsubscribe = subscribe(() => {
           const newState = getState()
           if (Object.is(hook.state, newState)) return

--- a/packages/lib/src/signals/computed.ts
+++ b/packages/lib/src/signals/computed.ts
@@ -111,10 +111,8 @@ export const useComputed = <T>(
 ) => {
   return useHook(
     "useComputedSignal",
-    {
-      signal: null! as ComputedSignal<T>,
-    },
-    ({ hook, isInit, vNode }) => {
+    { signal: null! as ComputedSignal<T> },
+    ({ hook, isInit, isHMR }) => {
       if (__DEV__) {
         hook.dev = {
           devtools: {
@@ -124,11 +122,8 @@ export const useComputed = <T>(
             }),
           },
         }
-        if (!isInit && vNode.hmrUpdated) {
-          // isInit would be true if this is our initial render or if  the
-          // getter was changed. In the case that our vNode was the subject
-          // of an HMR update but the getter did not change, we're ensuring a
-          // new signal is created to handle global signals being replaced.
+        if (isHMR) {
+          // useComputed is always considered side-effecty, so we need to re-run
           hook.cleanup?.()
           isInit = true
         }

--- a/packages/lib/src/signals/watch.ts
+++ b/packages/lib/src/signals/watch.ts
@@ -133,9 +133,9 @@ export function useWatch<const Deps extends readonly Signal<unknown>[]>(
   return useHook(
     "useWatch",
     { watcher: null as any as WatchEffect<Deps> },
-    ({ hook, isInit, vNode }) => {
+    ({ hook, isInit, isHMR }) => {
       if (__DEV__) {
-        if (vNode.hmrUpdated) {
+        if (isHMR) {
           hook.cleanup?.()
           isInit = true
         }

--- a/packages/lib/src/store.ts
+++ b/packages/lib/src/store.ts
@@ -128,12 +128,21 @@ function createStore<T, U extends MethodFactory<T>>(
     return useHook(
       "useStore",
       { value: null as any as T | R, lastChangeSync: -1 },
-      ({ hook, isInit, vNode, index, update }) => {
+      ({ hook, isInit, isHMR, vNode, index, update }) => {
         if (__DEV__) {
-          hook.dev = {
-            devtools: {
-              get: () => ({ value: hook.value }),
-            },
+          if (isInit) {
+            hook.dev = {
+              devtools: {
+                get: () => ({ value: hook.value }),
+              },
+              initialArgs: [sliceFn, equality],
+            }
+          } else if (isHMR) {
+            const [fn, eq] = hook.dev!.initialArgs
+            if (fn !== sliceFn || eq !== equality) {
+              isInit = true
+              hook.dev!.initialArgs = [sliceFn, equality]
+            }
           }
         }
         const { subscribers, nodeStateMap, epoch, value, methods } =

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -152,14 +152,9 @@ declare global {
       cleanup?: () => void
       name?: string
       dev?: {
+        /** Used to perform invalidation during HMR when the hook's arguments have changed */
+        initialArgs?: any
         devtools?: HookDevtoolsProvisions<any>
-        /**
-         * If set to `"persist"`, during development the hook will persist
-         * instead of being recreated when the raw arguments of the hook change.
-         * During the next render, `isInit` and `rawArgsChanged` will be set to `true`.
-         */
-        onRawArgsChanged?: "persist"
-        readonly rawArgsChanged?: boolean
       }
     }
     type RefObject<T> = {

--- a/sandbox/shared/src/UseSyncExternalStoreExample.store.ts
+++ b/sandbox/shared/src/UseSyncExternalStoreExample.store.ts
@@ -1,0 +1,19 @@
+export const myStore = new (class<T> {
+  #subscribers: Set<() => void>
+  #value: T
+  constructor(initial: T) {
+    this.#value = initial
+    this.#subscribers = new Set()
+  }
+  subscribe = (callback: () => void) => {
+    this.#subscribers.add(callback)
+    return () => this.#subscribers.delete(callback)
+  }
+  set = (next: T) => {
+    this.#value = next
+    this.#subscribers.forEach((fn) => fn())
+  }
+  get = () => {
+    return this.#value
+  }
+})(0)

--- a/sandbox/shared/src/UseSyncExternalStoreExample.tsx
+++ b/sandbox/shared/src/UseSyncExternalStoreExample.tsx
@@ -1,29 +1,8 @@
 import { useSyncExternalStore } from "kaioken"
-const myStore = new (class<T> {
-  #subscribers: Set<() => void>
-  #value: T
-  constructor(initial: T) {
-    this.#value = initial
-    this.#subscribers = new Set()
-  }
-  subscribe(callback: () => void) {
-    this.#subscribers.add(callback)
-    return () => this.#subscribers.delete(callback)
-  }
-  set(next: T) {
-    this.#value = next
-    this.#subscribers.forEach((fn) => fn())
-  }
-  get() {
-    return this.#value
-  }
-})(0)
+import { myStore } from "./UseSyncExternalStoreExample.store"
 
 export default function UseSyncExternalStoreExample() {
-  const value = useSyncExternalStore(
-    (cb) => myStore.subscribe(cb),
-    () => myStore.get()
-  )
+  const value = useSyncExternalStore(myStore.subscribe, myStore.get)
   return (
     <div>
       <h4>UseSyncExternalStoreExample</h4>


### PR DESCRIPTION
Previously, our approach for handling HMR + hooks was a bit naive and didn't properly take into account 'compound' hooks. This new approach puts responsibility on the creator of a 'raw hook' (ie. using `useHook`) to handle HMR response appropriately.