### PR TITLE
fix(ssg): include all stylesheets in rendered HTML

### DIFF
--- a/packages/lib/src/router/server/index.ts
+++ b/packages/lib/src/router/server/index.ts
@@ -66,11 +66,9 @@ export async function render(
   const is404Route = routeMatch.routeSegments.includes("404")
   const layoutEntries = matchLayouts(ctx.layouts, routeSegments)
 
-  if (__DEV__) {
-    ;[pageEntry, ...layoutEntries].forEach((e) => {
-      ctx.registerModule(e.absolutePath!)
-    })
-  }
+  ;[pageEntry, ...layoutEntries].forEach((e) => {
+    ctx.registerModule(e.absolutePath!)
+  })
 
   const [page, ...layouts] = await Promise.all([
     pageEntry.load() as unknown as Promise<PageModule>,

--- a/sandbox/docs/vite.config.ts
+++ b/sandbox/docs/vite.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       }),
     },
     kiru({
+      loggingEnabled: true,
       ssg: {
         page: "index.{tsx,mdx}",
         transition: false,


### PR DESCRIPTION
Pages generated by SSG had an issue upon load. Stylesheets were injected at runtime by Vite (basically after the HTML is loaded) were causing a visible jitter.

To resolve this, I updated the SSG to collect and add all necessary CSS files directly in the rendered HTML during build time.
It now provides tracking of modules while rendering: document, pages, and layout.
It collects CSS from the Vite manifest for all the tracked modules (It recursively follows the imports to get all CSS dependencies). 
It injects CSS links into the `<head>` before the HTML is written.

closes #51 