### PR TITLE
Implement useProps()

### DIFF
--- a/packages/lib/src/hooks/index.ts
+++ b/packages/lib/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from "./onCleanup.js"
 export * from "./onMount.js"
 export * from "./onBeforeMount.js"
+export * from "./useProps.js"
 export * from "./utils.js"

--- a/packages/lib/src/hooks/useProps.ts
+++ b/packages/lib/src/hooks/useProps.ts
@@ -1,0 +1,48 @@
+import { node } from "../globals.js"
+import { signal } from "../signals/index.js"
+import type { Signal } from "../signals/base.js"
+
+/**
+ * Returns the current component props and a `synced` helper to create signals
+ * that stay in sync with a prop (or derived value). Use during component setup
+ * when the component returns a render function.
+ *
+ * @example
+ * ```tsx
+ * const Counter: Kiru.FC<CounterProps> = () => {
+ *   const { synced } = useProps<CounterProps>()
+ *   const count = synced((props) => props.count ?? 0)
+ *
+ *   return () => (
+ *     <>
+ *       <p>Count: {count}</p>
+ *       <button onclick={() => count.value++}>Increment</button>
+ *     </>
+ *   )
+ * }
+ * ```
+ */
+export function useProps<P extends {}>(): {
+  synced: <T>(selector: (props: P extends Kiru.FC<infer R> ? R : P) => T) => Signal<T>
+} {
+  const vNode = node.current
+  if (!vNode) {
+    throw new Error("useProps must be called inside a Kiru component")
+  }
+
+  const propSyncs = (vNode.propSyncs ??= [])
+  type InferredProps = P extends Kiru.FC<infer R> ? R : P
+
+  return {
+    synced<T>(selector: (props: InferredProps) => T): Signal<T> {
+      const props = vNode.props as InferredProps
+      const sig = signal(selector(props))
+
+      propSyncs.push((currentProps) => {
+        sig.value = selector(currentProps as InferredProps)
+      })
+
+      return sig
+    },
+  }
+}

--- a/packages/lib/src/hooks/useProps.ts
+++ b/packages/lib/src/hooks/useProps.ts
@@ -38,8 +38,8 @@ export function useProps<P extends {}>(): {
   type InferredProps = P extends Kiru.FC<infer R> ? R : P
 
   return {
-    derive<T>(selector: (props: InferredProps) => T): Signal<T> {
-      const props = vNode.props as InferredProps
+    derive(selector) {
+      const props = { ...vNode.props } as InferredProps
       const sig = signal(selector(props))
 
       propSyncs.push((currentProps) => {

--- a/packages/lib/src/hooks/useProps.ts
+++ b/packages/lib/src/hooks/useProps.ts
@@ -3,15 +3,17 @@ import { signal } from "../signals/index.js"
 import type { Signal } from "../signals/base.js"
 
 /**
- * Returns the current component props and a `synced` helper to create signals
- * that stay in sync with a prop (or derived value). Use during component setup
+ * Returns a `derive` helper to create signals that stay in sync
+ * with a prop (or derived value). Use during component setup
  * when the component returns a render function.
  *
  * @example
  * ```tsx
+ * type CounterProps = { count?: number }
+ *
  * const Counter: Kiru.FC<CounterProps> = () => {
- *   const { synced } = useProps<CounterProps>()
- *   const count = synced((props) => props.count ?? 0)
+ *   const { derive } = useProps<CounterProps>()
+ *   const count = derive((props) => props.count ?? 0)
  *
  *   return () => (
  *     <>
@@ -23,7 +25,9 @@ import type { Signal } from "../signals/base.js"
  * ```
  */
 export function useProps<P extends {}>(): {
-  synced: <T>(selector: (props: P extends Kiru.FC<infer R> ? R : P) => T) => Signal<T>
+  derive: <T>(
+    selector: (props: P extends Kiru.FC<infer R> ? R : P) => T
+  ) => Signal<T>
 } {
   const vNode = node.current
   if (!vNode) {
@@ -34,7 +38,7 @@ export function useProps<P extends {}>(): {
   type InferredProps = P extends Kiru.FC<infer R> ? R : P
 
   return {
-    synced<T>(selector: (props: InferredProps) => T): Signal<T> {
+    derive<T>(selector: (props: InferredProps) => T): Signal<T> {
       const props = vNode.props as InferredProps
       const sig = signal(selector(props))
 

--- a/packages/lib/src/scheduler.ts
+++ b/packages/lib/src/scheduler.ts
@@ -349,57 +349,31 @@ function updateFunctionComponent(vNode: FunctionVNode): VNode | null {
         subs.clear()
       }
 
-      if (__DEV__) {
-        if (isHmrUpdate()) {
-          const { hooks, cleanups } = vNode
-          if (cleanups) {
-            Object.values(cleanups).forEach(call)
-            delete vNode.cleanups
-          }
-          if (hooks) {
-            const { preCleanups, postCleanups } = hooks
-            preCleanups.forEach(call)
-            postCleanups.forEach(call)
-            preCleanups.length = postCleanups.length = 0
-          }
-          delete vNode.propSyncs
-          delete vNode.render
+      if (__DEV__ && isHmrUpdate()) {
+        const { hooks, cleanups } = vNode
+        if (cleanups) {
+          Object.values(cleanups).forEach(call)
+          delete vNode.cleanups
         }
-
-        if (vNode.render) {
-          if (shouldSyncProps) vNode.propSyncs?.forEach((sync) => sync(props))
-          newChild = vNode.render(props)
-        } else {
-          newChild = latest(type)(props)
-          if (typeof newChild === "function") {
-            vNode.subs?.forEach(call)
-            vNode.render = newChild as (props: any) => unknown
-            if (shouldSyncProps) vNode.propSyncs?.forEach((sync) => sync(props))
-            newChild = vNode.render(props)
-          }
+        if (hooks) {
+          const { preCleanups, postCleanups } = hooks
+          preCleanups.forEach(call)
+          postCleanups.forEach(call)
+          preCleanups.length = postCleanups.length = 0
         }
-
-        if (++renderTryCount > CONSECUTIVE_DIRTY_LIMIT) {
-          throw new KiruError({
-            message:
-              "Too many re-renders. Kiru limits the number of renders to prevent an infinite loop.",
-            fatal: true,
-            vNode,
-          })
-        }
-        continue
+        delete vNode.propSyncs
+        delete vNode.render
       }
 
-      if (vNode.render) {
-        if (shouldSyncProps) vNode.propSyncs?.forEach((sync) => sync(props))
-        newChild = vNode.render(props)
-      } else {
-        newChild = type(props)
-        if (typeof newChild === "function") {
-          vNode.render = newChild as (props: any) => unknown
-          if (shouldSyncProps) vNode.propSyncs?.forEach((sync) => sync(props))
-          newChild = vNode.render(props)
-        }
+      newChild = renderFunctionComponent(vNode, type, props, shouldSyncProps)
+
+      if (__DEV__ && ++renderTryCount > CONSECUTIVE_DIRTY_LIMIT) {
+        throw new KiruError({
+          message:
+            "Too many re-renders. Kiru limits the number of renders to prevent an infinite loop.",
+          fatal: true,
+          vNode,
+        })
       }
     } while (isRenderDirtied)
 
@@ -407,6 +381,30 @@ function updateFunctionComponent(vNode: FunctionVNode): VNode | null {
   } finally {
     node.current = null
   }
+}
+
+function renderFunctionComponent(
+  vNode: FunctionVNode,
+  type: Function,
+  props: Record<string, unknown>,
+  shouldSyncProps: boolean
+): unknown {
+  const { render, propSyncs } = vNode
+
+  if (render) {
+    if (shouldSyncProps) propSyncs?.forEach((sync) => sync(props))
+    return render(props)
+  }
+
+  let newChild = latest(type)(props)
+  if (typeof newChild === "function") {
+    vNode.subs?.forEach(call) // unsub from signals observered during setup
+    vNode.render = newChild
+    if (shouldSyncProps) propSyncs?.forEach((sync) => sync(props))
+    newChild = newChild(props)
+  }
+
+  return newChild
 }
 
 function updateHostComponent(vNode: DomVNode): VNode | null {

--- a/packages/lib/src/tests/unit/renderToString.test.tsx
+++ b/packages/lib/src/tests/unit/renderToString.test.tsx
@@ -97,4 +97,26 @@ describe("renderToString", () => {
 
     assert.strictEqual(res, expected)
   })
+  it("useProps.synced uses prop value and default correctly", () => {
+    interface CounterProps {
+      count?: number
+    }
+    const Counter: Kiru.FC<CounterProps> = () => {
+      const { synced } = kiru.useProps<CounterProps>()
+      const count = synced((props) => props.count ?? 0)
+      return () => (
+        <div>
+          <span>Count: {count}</span>
+        </div>
+      )
+    }
+    assert.strictEqual(
+      renderToString(<Counter count={5} />),
+      `<div><span>Count: 5</span></div>`
+    )
+    assert.strictEqual(
+      renderToString(<Counter />),
+      `<div><span>Count: 0</span></div>`
+    )
+  })
 })

--- a/packages/lib/src/tests/unit/renderToString.test.tsx
+++ b/packages/lib/src/tests/unit/renderToString.test.tsx
@@ -97,26 +97,4 @@ describe("renderToString", () => {
 
     assert.strictEqual(res, expected)
   })
-  it("useProps.synced uses prop value and default correctly", () => {
-    interface CounterProps {
-      count?: number
-    }
-    const Counter: Kiru.FC<CounterProps> = () => {
-      const { synced } = kiru.useProps<CounterProps>()
-      const count = synced((props) => props.count ?? 0)
-      return () => (
-        <div>
-          <span>Count: {count}</span>
-        </div>
-      )
-    }
-    assert.strictEqual(
-      renderToString(<Counter count={5} />),
-      `<div><span>Count: 5</span></div>`
-    )
-    assert.strictEqual(
-      renderToString(<Counter />),
-      `<div><span>Count: 0</span></div>`
-    )
-  })
 })

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -193,6 +193,8 @@ declare global {
         post: LifecycleHookCallback[]
         postCleanups: (() => void)[]
       }
+      /** Run before each render with current props to sync prop-derived signals */
+      propSyncs?: ((props: VNode["props"]) => void)[]
       render?: (props: VNode["props"]) => unknown
     }
     interface VNodeSnapshot {

--- a/sandbox/csr/src/pages/index.tsx
+++ b/sandbox/csr/src/pages/index.tsx
@@ -1,71 +1,59 @@
-import {
-  Fragment,
-  signal,
-  effect,
-  Derive,
-  computed,
-  DevTools,
-  ElementProps,
-} from "kiru"
-
-const text = signal("Hello World!")
-const foo = signal({
-  foo: "bar",
-  baz: [1, 2, 3],
-  qux: {
-    quux: "quuux",
-  },
-})
-
-effect(() => {
-  console.log(text.value)
-  const intervalId = setInterval(() => {
-    count.value++
-  }, 1000)
-  return () => {
-    console.log("effect cleanup")
-    clearInterval(intervalId)
-  }
-})
+import { signal, computed, DevTools, ElementProps, useProps } from "kiru"
 
 const count = signal(0)
 const double = computed(() => count.value * 2)
 if (import.meta.env.DEV) {
   DevTools.track(count, "count")
   DevTools.track(double, "double")
-  DevTools.track(text, "text")
-  DevTools.track(foo, "foo")
 }
 
 export default function HomePage() {
   return (
     <>
-      <div className="mb-24">
-        <input bind:value={text} />
-        <Fragment key="test">test 123</Fragment>
-        <h1>Welcome Home!</h1>
-        <Derive from={text}>{(text) => <p>{text}</p>}</Derive>
-        <p>This page is wrapped by the root layout only.</p>
-        <p>
-          You can see the navigation header and footer from the root layout.
-        </p>
-      </div>
-      <p>Child</p>
-      <MyButton>Click me</MyButton>
+      <button onclick={() => count.value++}>Increment ({count})</button>
+      <MyButton initialCount={count.value}>Click me</MyButton>
     </>
   )
 }
 
-const MyButton: Kiru.FC<ElementProps<"button">> = () => {
-  const timesClicked = signal(0)
+interface CounterProps extends ElementProps<"button"> {
+  initialCount?: number
+}
+const MyButton: Kiru.FC<CounterProps> = () => {
+  const { synced } = useProps<CounterProps>()
+  const count = synced((props) => props.initialCount ?? 0)
+
   const handleClick = () => {
-    timesClicked.value++
+    count.value++
   }
 
-  return ({ children, ...props }) => (
-    <button onclick={(e) => (handleClick(), props.onclick?.(e))} {...props}>
-      {children}
-      {timesClicked}
-    </button>
-  )
+  return ({ children, ...props }) => {
+    return (
+      <button onclick={(e) => (handleClick(), props.onclick?.(e))} {...props}>
+        {children}
+        {count}
+      </button>
+    )
+  }
+}
+
+// we can also use the component type:
+const MyButton2: Kiru.FC<
+  ElementProps<"button"> & { initialCount?: number }
+> = () => {
+  const { synced } = useProps<typeof MyButton2>()
+  const count = synced((props) => props.initialCount ?? 0)
+
+  const handleClick = () => {
+    count.value++
+  }
+
+  return ({ children, ...props }) => {
+    return (
+      <button onclick={(e) => (handleClick(), props.onclick?.(e))} {...props}>
+        {children}
+        {count}
+      </button>
+    )
+  }
 }

--- a/sandbox/csr/src/pages/index.tsx
+++ b/sandbox/csr/src/pages/index.tsx
@@ -20,8 +20,8 @@ interface CounterProps extends ElementProps<"button"> {
   initialCount?: number
 }
 const MyButton: Kiru.FC<CounterProps> = () => {
-  const { synced } = useProps<CounterProps>()
-  const count = synced((props) => props.initialCount ?? 0)
+  const { derive } = useProps<CounterProps>()
+  const count = derive((props) => props.initialCount ?? 0)
 
   const handleClick = () => {
     count.value++
@@ -41,8 +41,8 @@ const MyButton: Kiru.FC<CounterProps> = () => {
 const MyButton2: Kiru.FC<
   ElementProps<"button"> & { initialCount?: number }
 > = () => {
-  const { synced } = useProps<typeof MyButton2>()
-  const count = synced((props) => props.initialCount ?? 0)
+  const { derive } = useProps<typeof MyButton2>()
+  const count = derive((props) => props.initialCount ?? 0)
 
   const handleClick = () => {
     count.value++

--- a/sandbox/csr/src/pages/index.tsx
+++ b/sandbox/csr/src/pages/index.tsx
@@ -36,24 +36,3 @@ const MyButton: Kiru.FC<CounterProps> = () => {
     )
   }
 }
-
-// we can also use the component type:
-const MyButton2: Kiru.FC<
-  ElementProps<"button"> & { initialCount?: number }
-> = () => {
-  const { derive } = useProps<typeof MyButton2>()
-  const count = derive((props) => props.initialCount ?? 0)
-
-  const handleClick = () => {
-    count.value++
-  }
-
-  return ({ children, ...props }) => {
-    return (
-      <button onclick={(e) => (handleClick(), props.onclick?.(e))} {...props}>
-        {children}
-        {count}
-      </button>
-    )
-  }
-}


### PR DESCRIPTION
With the new v1 component model, creating local state that depends on values from props is tedious and error prone.

```tsx
interface CounterProps {
  initialCount?: number
}

const Counter: Kiru.FC<CounterProps> = ({ initialCount }) => {
  const count = signal(initialCount ?? 0)
  let prevInitialCount = initialCount

  return ({ initialCount }) => {
    if (initialCount !== prevInitialCount) {
      count.value = initialCount ?? 0
      prevInitialCount = initialCount
    }
    return (
      <>
        <p>Count: {count}</p>
        <button onclick={() => count.value++}>Increment</button>
        <button onclick={() => count.value--}>Decrement</button>
      </>
    )
  }
}
```

To simplify this, `useProps()` is being introduced:
```tsx
const Counter: Kiru.FC<CounterProps> = () => {
  const { derive } = useProps<CounterProps>()
  const count = derive((props) => props.initialCount ?? 0)

  return () => (
    <>
      <p>Count: {count}</p>
      <button onclick={() => count.value++}>Increment</button>
      <button onclick={() => count.value--}>Decrement</button>
    </>
  )
}
```
> Use `derive()` to create a signal that's automatically updated when the component receives new props.

When the [Partial Type Argument Inference](https://github.com/microsoft/TypeScript/issues/26242) spec (or something similar) goes through, we can provide a cleaner API that doesn't require more than one step.