### PR TITLE
 link: Add manifest relation support (rel="manifest")

### DIFF
--- a/packages/lib/src/types.dom.ts
+++ b/packages/lib/src/types.dom.ts
@@ -273,6 +273,7 @@ type LinkRel =
   | "stylesheet"
   | "tag"
   | "up"
+  | "manifest"
 
 type Loading = "eager" | "lazy"
 


### PR DESCRIPTION
**Change:**
Implement rel="manifest" link type value for HTML <link> element.

**Reasoning:**
Indicates target resource is Web app manifest.
Improves compatibility/support for modern PWA linking mechanisms.
Adoption high on Chromium-based browsers (Chrome, Edge, Opera).

**Gap:** 
Firefox browser currently lacks support. Still adding despite gap due to market share dominance elsewhere.

[MDN Doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/manifest)